### PR TITLE
Update deprecating hash method in raw_image_provider.dart

### DIFF
--- a/spine-flutter/lib/raw_image_provider.dart
+++ b/spine-flutter/lib/raw_image_provider.dart
@@ -94,7 +94,7 @@ class _RawImageKey {
 
   @override
   int get hashCode {
-    return hashValues(w, h, format, dataHash.hashCode);
+    return Object.hash(w, h, format, dataHash.hashCode);
   }
 }
 


### PR DESCRIPTION
```
Running pod install...                                             747ms
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:arm64, id:00008103-000329201AD1001E, name:My Mac }
{ platform:macOS, arch:x86_64, id:00008103-000329201AD1001E, name:My Mac }
../../.pub-cache/hosted/pub.dev/spine_flutter-4.2.32/lib/raw_image_provider.dart:97:12: Error: The method 'hashValues' isn't defined for the class '_RawImageKey'.
 - '_RawImageKey' is from 'package:spine_flutter/raw_image_provider.dart' ('../../.pub-cache/hosted/pub.dev/spine_flutter-4.2.32/lib/raw_image_provider.dart').
Try correcting the name to the name of an existing method, or defining a method named 'hashValues'.
    return hashValues(w, h, format, dataHash.hashCode);
           ^^^^^^^^^^
Target kernel_snapshot_program failed: Exception

Command PhaseScriptExecution failed with a nonzero exit code
** BUILD FAILED **

Building macOS application...                                           
Error: Build process failed
```

In an upcoming version of Flutter that is currently available on the beta and master channels, the old `hashValues` method has been deprecated. I'm not modifying the Flutter version in this PR, just helping the project get ready for that eventual transition.